### PR TITLE
OS X compatibility 

### DIFF
--- a/multimap-library-jni.pro
+++ b/multimap-library-jni.pro
@@ -14,7 +14,8 @@ isEmpty(JAVA_HOME) {
 
 INCLUDEPATH += \
     $$JAVA_HOME/include \
-    $$JAVA_HOME/include/linux
+    $$JAVA_HOME/include/linux \
+    $$JAVA_HOME/include/darwin
 
 HEADERS += \
     src/cpp/multimap/jni/generated/io_multimap_Iterator_Native.h \

--- a/multimap-tool.pro
+++ b/multimap-tool.pro
@@ -8,6 +8,11 @@ QMAKE_CXXFLAGS += -std=c++11
 
 SOURCES += src/cpp/multimap/command_line_tool.cpp
 
+macx {
+    INCLUDEPATH += /usr/local/include
+    LIBS += -L/usr/local/lib
+}
+
 unix: LIBS += -lboost_filesystem -lboost_system -lmultimap
 
 unix {

--- a/multimap.pri
+++ b/multimap.pri
@@ -39,4 +39,9 @@ SOURCES += \
     src/cpp/multimap/thirdparty/xxhash/xxhash.c \
     src/cpp/multimap/Map.cpp
 
-unix|win32: LIBS += -lboost_filesystem -lboost_system -lboost_thread -pthread
+unix:!macx|win32: LIBS += -lboost_filesystem -lboost_system -lboost_thread -pthread
+
+macx {
+    INCLUDEPATH += /usr/local/include
+    LIBS += -L/usr/local/lib -lboost_filesystem -lboost_system -lboost_thread-mt
+}

--- a/src/cpp/multimap/command_line_tool.cpp
+++ b/src/cpp/multimap/command_line_tool.cpp
@@ -116,7 +116,7 @@ multimap::Options initOptions(const CommandLine& cmd) {
 
 void runHelpCommand(const char* toolname) {
   // clang-format off
-  const multimap::Options default_options;
+  const multimap::Options default_options {};
   std::printf(
       "USAGE\n"
       "\n  %s COMMAND PATH_TO_MAP [PATH] [OPTIONS]"


### PR DESCRIPTION
Hey Martin,

This PR makes it possible to compile all multimap artifacts with clang on OS X. Would be nice to have it in the master :wink:.

I could also provide you with the install instructions. Interested?